### PR TITLE
Feature/global exception handler

### DIFF
--- a/src/main/java/com/kalgory/kp/api/exception/CustomErrorAttributes.java
+++ b/src/main/java/com/kalgory/kp/api/exception/CustomErrorAttributes.java
@@ -1,0 +1,23 @@
+package com.kalgory.kp.api.exception;
+
+import java.util.Map;
+import org.springframework.boot.web.error.ErrorAttributeOptions;
+import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.WebRequest;
+
+/**
+ * 에러 응답 형태를 변경하는 컴포넌트.
+ */
+@Component
+public class CustomErrorAttributes extends DefaultErrorAttributes {
+
+  @Override
+  public Map<String, Object> getErrorAttributes(
+      WebRequest webRequest,
+      ErrorAttributeOptions options) {
+    Map<String, Object> errorAttributes = super.getErrorAttributes(webRequest, options);
+    errorAttributes.remove("path");
+    return errorAttributes;
+  }
+}

--- a/src/main/java/com/kalgory/kp/api/exception/CustomException.java
+++ b/src/main/java/com/kalgory/kp/api/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.kalgory.kp.api.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * UncheckedException을 처리하기 위한 커스텀 예외 클래스.
+ */
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+}

--- a/src/main/java/com/kalgory/kp/api/exception/ErrorCode.java
+++ b/src/main/java/com/kalgory/kp/api/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.kalgory.kp.api.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 커스텀 예외에 사용되는 에러 코드.
+ */
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+  DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류입니다.");
+
+  private final HttpStatus status;
+  private final String message;
+}

--- a/src/main/java/com/kalgory/kp/api/exception/ErrorResponse.java
+++ b/src/main/java/com/kalgory/kp/api/exception/ErrorResponse.java
@@ -1,0 +1,34 @@
+package com.kalgory.kp.api.exception;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 예외 발생 시 반환하는 응답 형태.
+ */
+@Getter
+@Builder
+public class ErrorResponse {
+
+  private final LocalDateTime timestamp = LocalDateTime.now();
+  private final int status;
+  private final String error;
+  private final String code;
+  private final String message;
+
+  /**
+   * ErrorCode 열거형 객체로부터 ErrorResponse 인스턴스를 반환하는 정적 메서드.
+   *
+   * @param errorCode ErrorCode 열거형 객체
+   * @return ErrorResponse 객체
+   */
+  public static ErrorResponse from(ErrorCode errorCode) {
+    return ErrorResponse.builder()
+        .status(errorCode.getStatus().value())
+        .error(errorCode.getStatus().name())
+        .code(errorCode.name())
+        .message(errorCode.getMessage())
+        .build();
+  }
+}

--- a/src/main/java/com/kalgory/kp/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kalgory/kp/api/exception/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.kalgory.kp.api.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 전역 예외 핸들러.
+ */
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+  /**
+   * 커스텀 예외를 처리하는 핸들러.
+   *
+   * @param customException 커스텀 예외 클래스
+   * @return ErrorResponse 클래스
+   */
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<ErrorResponse> handleCustomException(CustomException customException) {
+    log.error("handleCustomException: {}", customException.getErrorCode());
+    return ResponseEntity
+        .status(customException.getErrorCode().getStatus().value())
+        .body(ErrorResponse.from(customException.getErrorCode()));
+  }
+
+  /**
+   * 커스텀 예외를 제외한 모든 예외를 처리하는 핸들러.
+   *
+   * @param exception 최상위 예외 클래스
+   * @return ErrorResponse 클래스
+   */
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleAllException(Exception exception) {
+    log.error("handleAllException: {}", exception.getMessage());
+    return ResponseEntity
+        .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus().value())
+        .body(ErrorResponse.from(ErrorCode.INTERNAL_SERVER_ERROR));
+  }
+}

--- a/src/main/java/com/kalgory/kp/api/service/UserService.java
+++ b/src/main/java/com/kalgory/kp/api/service/UserService.java
@@ -2,6 +2,8 @@ package com.kalgory.kp.api.service;
 
 import com.kalgory.kp.api.dto.UserSignUpRequestDto;
 import com.kalgory.kp.api.entity.user.Users;
+import com.kalgory.kp.api.exception.CustomException;
+import com.kalgory.kp.api.exception.ErrorCode;
 import com.kalgory.kp.api.repository.UsersRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -26,9 +28,9 @@ public class UserService {
    */
   public void signUp(UserSignUpRequestDto userSignUpRequestDto) {
     String email = userSignUpRequestDto.getEmail();
-    // TODO: 글로벌 예외 처리
+
     if (usersRepository.existsByEmail(email)) {
-      throw new IllegalStateException("이미 존재하는 유저입니다.");
+      throw new CustomException(ErrorCode.DUPLICATED_EMAIL);
     }
     String encodedPassword = passwordEncoder.encode(userSignUpRequestDto.getPassword());
     Users user = Users.of(userSignUpRequestDto, encodedPassword);


### PR DESCRIPTION
## Feature 역할

전역 예외 처리 설정 및 적용

## 변경점
- CustomException.java: RuntimeException을 처리하기 위한 클래스입니다. ErrorCode를 필드값으로 가지고 있습니다.
- ErrorCode.java: CustomException의 필드값으로 어떤 예외가 발생했을 때 어떤 응답코드를 반환할지 설정하기 위해 만든 enum 클래스입니다. Http 응답 상태코드와 메시지를 가지고 있습니다.
- ErrorResponse.java: 컨트롤러에서 반환하는 에러 응답 형태입니다. 아래와 같은 형식을 가집니다.
```json
{
    "timestamp": "2022-02-24T15:40:22.0818798",
    "status": 400,
    "error": "BAD_REQUEST",
    "code": "DUPLICATED_EMAIL",
    "message": "이미 존재하는 이메일입니다."
}
```
- CustomErrorAttributes.java: 컨트롤러에서 발생한 예외가 아니라 서블릿 컨테이너(톰캣)에서 발생한 예외를 처리할 때 사용되는 응답 형태를 커스터마이징하기 위해 만든 클래스입니다. 
컨트롤러에서 반환하는 에러 응답 형태와 유사하게 만들기 위해 "path" 속성을 제거하였습니다. 아래와 같은 형식을 가집니다.
```json
{
    "timestamp": "2022-02-24T06:49:20.909+00:00",
    "status": 404,
    "error": "Not Found"
}
```
- GlobalExceptionHandler.java: CustomException을 처리하기 위해 등록한 핸들러입니다. CustomException을 제외한 모든 예외는 `Internal Service Error`로 처리하였습니다.
- UserService.java: 이미 존재하는 이메일로 회원가입하려는 경우 400 Bad Request 응답 코드를 보냅니다.

## 논의해야 될 부분(문법 혹은 쿼리 등)
- ErrorResponse의 형태는 논의 후에 Auth 서버와 통일하는 것이 좋을 것 같습니다. 
- 성공했을 때의 응답도 같이 논의해보았으면 합니다.