### PR TITLE
KB-28 - KB-28-유저-테스트-코드-작성

### DIFF
--- a/src/main/java/com/kalgory/kp/api/controller/UserController.java
+++ b/src/main/java/com/kalgory/kp/api/controller/UserController.java
@@ -5,6 +5,7 @@ import com.kalgory.kp.api.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,7 +20,7 @@ public class UserController {
 
   @PostMapping("/sign-up")
   @ResponseStatus(HttpStatus.CREATED)
-  public void registerUser(UserSignUpRequestDto userSignUpRequestDto) {
+  public void registerUser(@RequestBody UserSignUpRequestDto userSignUpRequestDto) {
     userService.signUp(userSignUpRequestDto);
   }
 }

--- a/src/main/java/com/kalgory/kp/api/service/UserService.java
+++ b/src/main/java/com/kalgory/kp/api/service/UserService.java
@@ -5,7 +5,7 @@ import com.kalgory.kp.api.entity.user.Users;
 import com.kalgory.kp.api.exception.CustomException;
 import com.kalgory.kp.api.exception.ErrorCode;
 import com.kalgory.kp.api.repository.UsersRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -13,13 +13,11 @@ import org.springframework.stereotype.Service;
  * 유저 관련 서비스 클래스.
  */
 @Service
+@RequiredArgsConstructor
 public class UserService {
 
-  @Autowired
-  private PasswordEncoder passwordEncoder;
-
-  @Autowired
-  private UsersRepository usersRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final UsersRepository usersRepository;
 
   /**
    * 회원가입 로직.
@@ -28,12 +26,20 @@ public class UserService {
    */
   public void signUp(UserSignUpRequestDto userSignUpRequestDto) {
     String email = userSignUpRequestDto.getEmail();
+    validateEmail(email);
 
+    Users user = getUserFrom(userSignUpRequestDto);
+    usersRepository.save(user);
+  }
+
+  private void validateEmail(String email) {
     if (usersRepository.existsByEmail(email)) {
       throw new CustomException(ErrorCode.DUPLICATED_EMAIL);
     }
+  }
+
+  private Users getUserFrom(UserSignUpRequestDto userSignUpRequestDto) {
     String encodedPassword = passwordEncoder.encode(userSignUpRequestDto.getPassword());
-    Users user = Users.of(userSignUpRequestDto, encodedPassword);
-    usersRepository.save(user);
+    return Users.of(userSignUpRequestDto, encodedPassword);
   }
 }

--- a/src/main/java/com/kalgory/kp/api/service/UserService.java
+++ b/src/main/java/com/kalgory/kp/api/service/UserService.java
@@ -28,7 +28,8 @@ public class UserService {
     String email = userSignUpRequestDto.getEmail();
     validateEmail(email);
 
-    Users user = getUserFrom(userSignUpRequestDto);
+    Users user = Users.of(userSignUpRequestDto,
+        passwordEncoder.encode(userSignUpRequestDto.getPassword()));
     usersRepository.save(user);
   }
 
@@ -36,10 +37,5 @@ public class UserService {
     if (usersRepository.existsByEmail(email)) {
       throw new CustomException(ErrorCode.DUPLICATED_EMAIL);
     }
-  }
-
-  private Users getUserFrom(UserSignUpRequestDto userSignUpRequestDto) {
-    String encodedPassword = passwordEncoder.encode(userSignUpRequestDto.getPassword());
-    return Users.of(userSignUpRequestDto, encodedPassword);
   }
 }

--- a/src/test/java/com/kalgory/kp/api/service/UserServiceTest.java
+++ b/src/test/java/com/kalgory/kp/api/service/UserServiceTest.java
@@ -1,0 +1,80 @@
+package com.kalgory.kp.api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.kalgory.kp.api.dto.UserSignUpRequestDto;
+import com.kalgory.kp.api.exception.CustomException;
+import com.kalgory.kp.api.exception.ErrorCode;
+import com.kalgory.kp.api.repository.UsersRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+  @InjectMocks
+  private UserService userService;
+
+  @Mock
+  private UsersRepository usersRepository;
+
+  @Mock
+  private PasswordEncoder passwordEncoder;
+
+  @Test
+  @DisplayName("회원가입 정상 흐름")
+  void signUp() {
+    // given
+    String email = "test@gmail.com";
+    String password = "test";
+    UserSignUpRequestDto userSignUpRequestDto = UserSignUpRequestDto.builder()
+        .email(email)
+        .password(password)
+        .username("test")
+        .profileImage("test.jpg")
+        .build();
+    // when
+    when(usersRepository.existsByEmail(email)).thenReturn(false);
+    when(usersRepository.save(Mockito.any())).thenReturn(Mockito.any());
+    when(passwordEncoder.encode(password)).thenReturn(password);
+    // then
+    Assertions.assertDoesNotThrow(() -> userService.signUp(userSignUpRequestDto));
+    verify(usersRepository).existsByEmail(email);
+    verify(usersRepository).save(Mockito.any());
+    verify(passwordEncoder).encode(password);
+  }
+
+  @Test
+  @DisplayName("중복 이메일로 회원가입 시도")
+  void signUpDuplicateEmail() {
+    // given
+    String email = "test@gmail.com";
+    String password = "test";
+    UserSignUpRequestDto userSignUpRequestDto = UserSignUpRequestDto.builder()
+        .email(email)
+        .password(password)
+        .username("test")
+        .profileImage("test.jpg")
+        .build();
+    // when
+    when(usersRepository.existsByEmail(email)).thenReturn(true);
+    // then
+    CustomException customException = assertThrowsExactly(CustomException.class,
+        () -> userService.signUp(userSignUpRequestDto));
+    assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.DUPLICATED_EMAIL);
+    verify(usersRepository).existsByEmail(email);
+    verify(usersRepository, never()).save(Mockito.any());
+    verify(passwordEncoder, never()).encode(password);
+  }
+}


### PR DESCRIPTION
## Feature 역할

회원가입에 대한 단위 테스트 코드 작성

## 변경점
- UserController.java : `@RequestBody` 어노테이션 명시
- UserService.java: 메서드 분리
- UserServiceTest.java: 회원가입 정상 흐름과 중복 이메일이 발생했을 때에 대한 테스트 코드 작성

## 논의해야 될 부분(문법 혹은 쿼리 등)
테스트 메서드 이름을 통일할 필요가 있을 것 같습니다! `@DisplayName`을 사용하지 않고 한글 메서드를 사용한다거나 아니면 메서드 끝에 _Test 접미사를 붙인다거나 등등...